### PR TITLE
CMMPPT updated to compile and link

### DIFF
--- a/sce/src/appl.mk
+++ b/sce/src/appl.mk
@@ -63,6 +63,9 @@ odbc_compiler_flag	= -DSCE_ODBC
 PTRPATHOPTS     = -ptr./ptrepository -ptr../../wit/$(platform)/ptrepository
 
 vpath %.$(cxx_suffix) $(src_dir)
+vpath %.h             $(src_dir)
+vpath %.y             $(src_dir)
+vpath %.l             $(src_dir)
 
 libsce.a:      $(lib_objects)
 	$(AR) $(ds_ar_update_flags) $@ $^
@@ -76,8 +79,8 @@ libsce.a:      $(lib_objects)
 #	$(WIT_ROOT_DIR)/$(platform)/libwitnl.a 
 
 typical_scenario_libraries = \
-	$(SCENARIO_ROOT_DIR)/$(platform)/libscen.a \
-	$(WIT_ROOT_DIR)/$(platform)/libwit.a \
+	$(WIT_ROOT_DIR)/../scenario/$(platform)/libscen.a \
+	$(WIT_ROOT_DIR)/../wit/$(platform)/libwit.a \
 	$(WIT_ROOT_DIR)/../mcl/$(platform)/libmcl.a
 
 

--- a/sce/src/difSceF.C
+++ b/sce/src/difSceF.C
@@ -1,4 +1,4 @@
-#include <mcl/src/mdsPragma.h>
+//#include <mcl/src/mdsPragma.h>
 
 #include <string>
 #include <ostream>

--- a/sce/src/ipSce.C
+++ b/sce/src/ipSce.C
@@ -1,4 +1,4 @@
-#include <mcl/src/mdsPragma.h>
+//#include <mcl/src/mdsPragma.h>
 // RW2STL - inserted:
 #include <string>
 #include <ostream>

--- a/sce/src/scBdSce.C
+++ b/sce/src/scBdSce.C
@@ -1,4 +1,4 @@
-#include <mcl/src/mdsPragma.h>
+//#include <mcl/src/mdsPragma.h>
 // RW2STL - inserted:
 #include <ostream>
 #include <scenario/src/RWToSTLHelpers.h>

--- a/sce/src/sceCrtLs.C
+++ b/sce/src/sceCrtLs.C
@@ -1,4 +1,4 @@
-#include <mcl/src/mdsPragma.h>
+//#include <mcl/src/mdsPragma.h>
 // RW2STL - inserted:
 #include <string>
 // End of RW2STL - inserted includes.

--- a/sce/src/sceDefin.h
+++ b/sce/src/sceDefin.h
@@ -4,7 +4,7 @@
 #define LGFRSCEDEFINE_H
 #include <stdlib.h>
 
-#include <mcl/src/mdsPragma.h>
+//#include <mcl/src/mdsPragma.h>
 
 // USE THIS FOR MEMORY DEBUGGING
 // #ifndef ELIMINATE_OLD_MAIN

--- a/sce/src/sceFssMg.C
+++ b/sce/src/sceFssMg.C
@@ -1,4 +1,4 @@
-#include <mcl/src/mdsPragma.h>
+//#include <mcl/src/mdsPragma.h>
 // RW2STL - inserted:
 #include <string>
 #include <ostream>

--- a/sce/src/scePegging.C
+++ b/sce/src/scePegging.C
@@ -1,4 +1,4 @@
-#include <mcl/src/mdsPragma.h>
+//#include <mcl/src/mdsPragma.h>
 // RW2STL - inserted:
 #include <map>
 #include <string>

--- a/sce/src/scePegging.h
+++ b/sce/src/scePegging.h
@@ -11,6 +11,7 @@
 #endif
 
 #include <wit/src/wit.h>
+#include <string.h>
 
 // forward declarations
 class LgFrMultiPlantHelper;

--- a/sce/src/scemain.C
+++ b/sce/src/scemain.C
@@ -1,4 +1,4 @@
-#include <mcl/src/mdsPragma.h>
+//#include <mcl/src/mdsPragma.h>
 // RW2STL - inserted:
 #include <string>
 #include <ostream>

--- a/scenario/src/RWToSTLHelpers.C
+++ b/scenario/src/RWToSTLHelpers.C
@@ -9,6 +9,7 @@
 #include <iosfwd>
 #include <ostream>
 #include <assert.h>
+#include <string.h>
 
 // General std::string functions previously done in RWCString
 // Note that these may not work for wide-character strings

--- a/scenario/src/dateTime.C
+++ b/scenario/src/dateTime.C
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <math.h>
+#include <string.h>
 
 const unsigned int secsPerDay = 86400; // quit saying "sex per day", it's "secs per day"
 // This is used to interpret the 2-digit values passed-in for years as being before or after 2000

--- a/wit/src/PtrVec.h
+++ b/wit/src/PtrVec.h
@@ -248,7 +248,7 @@ template <typename Elem>
       // Copy constructor function.
       //------------------------------------------------------------------------
 
-      inline WitPtrVecCompFtor (WitPtrVecCompFtor & theFtor):
+      inline WitPtrVecCompFtor (const WitPtrVecCompFtor & theFtor):
 
             myCompFunc_ (theFtor.myCompFunc_)
          {


### PR DESCRIPTION
Several changes were made to get CMMPPT to build with the current g++ compiler:

- wit/src
--PtrVec.h: A `const` was added to a function header because the compiler now catches what was a coding mistake

- scenario/src
--dateTime.C, RWToSTLHelpers.C: added `#include <string.h>` 

- sce/src
--scemain.C sceDefin.h difSceF.C ipSce.C scBDSce.c sceCrtLs.C sceFssMg.C scePegging.C: commented out `#include <mcl/src/mdsPragma.h>`
--scePegging.h: added `#include <string.h>`