### PR TITLE
Revised the legal notices as appropriate for open source.

### DIFF
--- a/mcl/src/arg.C
+++ b/mcl/src/arg.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //-----------------------------------------------------------------------------

--- a/mcl/src/arg.h
+++ b/mcl/src/arg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_arg_h

--- a/mcl/src/defs.h
+++ b/mcl/src/defs.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_defs_h

--- a/mcl/src/facility.C
+++ b/mcl/src/facility.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //-----------------------------------------------------------------------------

--- a/mcl/src/facility.h
+++ b/mcl/src/facility.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_facility_h

--- a/mcl/src/level.C
+++ b/mcl/src/level.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //-----------------------------------------------------------------------------

--- a/mcl/src/level.h
+++ b/mcl/src/level.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_level_h

--- a/mcl/src/mcl.h
+++ b/mcl/src/mcl.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_mcl_h

--- a/mcl/src/msg.C
+++ b/mcl/src/msg.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //-----------------------------------------------------------------------------

--- a/mcl/src/msg.h
+++ b/mcl/src/msg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_msg_h

--- a/mcl/src/output.C
+++ b/mcl/src/output.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //-----------------------------------------------------------------------------

--- a/mcl/src/output.h
+++ b/mcl/src/output.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_output_h

--- a/mcl/src/set.C
+++ b/mcl/src/set.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //-----------------------------------------------------------------------------

--- a/mcl/src/set.h
+++ b/mcl/src/set.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_set_h

--- a/mcl/src/unitTest.C
+++ b/mcl/src/unitTest.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //-----------------------------------------------------------------------------

--- a/mcl/src/unitTest.h
+++ b/mcl/src/unitTest.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
 // Message Class Library
 //
 // (C) Copyright IBM Corp. 1997, 2005  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef mcl_unitTest_h

--- a/wit/api-test/no-cplex-out-linux.txt
+++ b/wit/api-test/no-cplex-out-linux.txt
@@ -7,19 +7,19 @@ WIT0338W One or more of the names given in the input is more than 12 characters
          The longest name was: "Grilled_Cheese_Sandwich".
 
 
-=======================================================
+=============================================================
 Licensed Materials - Property of IBM
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 
 (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
 
 US Government Users Restricted Rights -
 Use, duplication or disclosure restricted by
 GSA ADP Schedule Contract with IBM Corp.
-=======================================================
+=============================================================
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 Release         8.0
 Build Date:     Jan  4 2013
 Build Type:     debug
@@ -71,19 +71,19 @@ WIT0106I The number of times warning messages will be displayed has been
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -2498,19 +2498,19 @@ WIT0098I WIT function witOptPreprocess entered.
 WIT0098I WIT function witDisplayData entered.
 WIT0100I The file "stdout" will be accessed.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -4441,19 +4441,19 @@ WIT0100I The file "apiAll.data" will be accessed.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -5289,19 +5289,19 @@ Idx  Crit     Crit  Dem     Dem  Ship
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -6030,19 +6030,19 @@ WIT0100I The file "obj1-test.data" will be accessed.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -6162,19 +6162,19 @@ WIT0708I This WitRun is now in a postprocessed state.
 
 WIT0098I WIT function witCopyData entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -6200,19 +6200,19 @@ WIT0709I This WitRun is now in an unpostprocessed state.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -6226,19 +6226,19 @@ WIT0117I nPeriods changed from 26 to 5.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -6580,19 +6580,19 @@ WIT0098I WIT function witGetOperationExists entered.
 
 WIT0098I WIT function witCopyData entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -6613,19 +6613,19 @@ WIT0100I The file "opnTest.data" will be accessed.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -6665,19 +6665,19 @@ add part "part1" capacity;
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -6986,19 +6986,19 @@ WIT0155I Preprocessing.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -7079,19 +7079,19 @@ WIT0524I A BOP entry for the production of part "partWithOperation" is being
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -7129,19 +7129,19 @@ WIT0524I A BOP entry for the production of part "partWithOperation" is being
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -7227,19 +7227,19 @@ WIT0326I Part name is PC.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -7347,19 +7347,19 @@ WIT0709I This WitRun is now in an unpostprocessed state.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -7467,19 +7467,19 @@ WIT0709I This WitRun is now in an unpostprocessed state.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -7583,19 +7583,19 @@ WIT0709I This WitRun is now in an unpostprocessed state.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -7699,19 +7699,19 @@ WIT0709I This WitRun is now in an unpostprocessed state.
 
 WIT function witInitialize entered.
 
-=======================================================
+=============================================================
 Licensed Materials - Property of IBM
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 
 (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
 
 US Government Users Restricted Rights -
 Use, duplication or disclosure restricted by
 GSA ADP Schedule Contract with IBM Corp.
-=======================================================
+=============================================================
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 Release         8.0
 Build Date:     Jan  4 2013
 Build Type:     debug
@@ -7878,19 +7878,19 @@ selForDel changed from TRUE to FALSE.
 
 WIT0098I WIT function witCopyData entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -7902,19 +7902,19 @@ Preprocessing.
 
 WIT function witInitialize entered.
 
-=======================================================
+=============================================================
 Licensed Materials - Property of IBM
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 
 (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
 
 US Government Users Restricted Rights -
 Use, duplication or disclosure restricted by
 GSA ADP Schedule Contract with IBM Corp.
-=======================================================
+=============================================================
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 Release         8.0
 Build Date:     Jan  4 2013
 Build Type:     debug
@@ -7933,19 +7933,19 @@ The file "delTest.data" will be accessed.
 WIT function witDisplayData entered.
 The file "stdout" will be accessed.
 
-=======================================================
+=============================================================
 Licensed Materials - Property of IBM
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 
 (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
 
 US Government Users Restricted Rights -
 Use, duplication or disclosure restricted by
 GSA ADP Schedule Contract with IBM Corp.
-=======================================================
+=============================================================
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 Release         8.0
 Build Date:     Jan  4 2013
 Build Type:     debug
@@ -9132,19 +9132,19 @@ Object purge complete.
 WIT function witDisplayData entered.
 The file "stdout" will be accessed.
 
-=======================================================
+=============================================================
 Licensed Materials - Property of IBM
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 
 (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
 
 US Government Users Restricted Rights -
 Use, duplication or disclosure restricted by
 GSA ADP Schedule Contract with IBM Corp.
-=======================================================
+=============================================================
 
-Watson Implosion Technology
+Constrained Materials Management and Production Planning Tool
 Release         8.0
 Build Date:     Jan  4 2013
 Build Type:     debug
@@ -9626,19 +9626,19 @@ The file format is "bsv."
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -9709,19 +9709,19 @@ WIT0120I postprocessed returned.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -10027,19 +10027,19 @@ WIT0120I extOptActive returned.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -10246,19 +10246,19 @@ WIT0327I Demand name is G.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -10333,19 +10333,19 @@ WIT0183I selForDel changed from FALSE to TRUE.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -10496,19 +10496,19 @@ WIT0327I Demand name is D.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -10590,19 +10590,19 @@ WIT0709I This WitRun is now in an unpostprocessed state.
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug
@@ -10656,19 +10656,19 @@ The following explodeable cycle was found:
 
 WIT0098I WIT function witInitialize entered.
 WIT0097I 
-         =======================================================
+         =============================================================
          Licensed Materials - Property of IBM
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          
          (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
          
          US Government Users Restricted Rights -
          Use, duplication or disclosure restricted by
          GSA ADP Schedule Contract with IBM Corp.
-         =======================================================
+         =============================================================
          
-         Watson Implosion Technology
+         Constrained Materials Management and Production Planning Tool
          Release         8.0
          Build Date:     Jan  4 2013
          Build Type:     debug

--- a/wit/src/AbortApiExc.h
+++ b/wit/src/AbortApiExc.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef AbortApiExcH

--- a/wit/src/AltPt.h
+++ b/wit/src/AltPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef AltPtH

--- a/wit/src/ApiCall.C
+++ b/wit/src/ApiCall.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/ApiCall.h
+++ b/wit/src/ApiCall.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ApiCallH

--- a/wit/src/ApiMgr.C
+++ b/wit/src/ApiMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/ApiMgr.h
+++ b/wit/src/ApiMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ApiMgrH

--- a/wit/src/Assoc.h
+++ b/wit/src/Assoc.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef AssocH

--- a/wit/src/AttRepos.h
+++ b/wit/src/AttRepos.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef AttReposH

--- a/wit/src/AvSorter.h
+++ b/wit/src/AvSorter.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef AvSorterH

--- a/wit/src/AvailSched.C
+++ b/wit/src/AvailSched.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/AvailSched.h
+++ b/wit/src/AvailSched.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef AvailSchedH

--- a/wit/src/BaCand.h
+++ b/wit/src/BaCand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BaCandH

--- a/wit/src/BaDir.h
+++ b/wit/src/BaDir.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BaDirH

--- a/wit/src/BaMat.h
+++ b/wit/src/BaMat.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BaMatH

--- a/wit/src/BaMgr.h
+++ b/wit/src/BaMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BaMgrH

--- a/wit/src/BaPt.h
+++ b/wit/src/BaPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BaPtH

--- a/wit/src/Below.h
+++ b/wit/src/Below.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BelowH

--- a/wit/src/BillEntry.C
+++ b/wit/src/BillEntry.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/BillEntry.h
+++ b/wit/src/BillEntry.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BillEntryH

--- a/wit/src/BomEntry.C
+++ b/wit/src/BomEntry.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/BomEntry.h
+++ b/wit/src/BomEntry.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BomEntryH

--- a/wit/src/BopEntry.C
+++ b/wit/src/BopEntry.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/BopEntry.h
+++ b/wit/src/BopEntry.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BopEntryH

--- a/wit/src/BoundPair.h
+++ b/wit/src/BoundPair.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BoundPairH

--- a/wit/src/BoundSet.C
+++ b/wit/src/BoundSet.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/BoundSet.h
+++ b/wit/src/BoundSet.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef BoundSetH

--- a/wit/src/BuildAhd.C
+++ b/wit/src/BuildAhd.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/BuildDate.C
+++ b/wit/src/BuildDate.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/CShipBS.h
+++ b/wit/src/CShipBS.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CShipBSH

--- a/wit/src/Capacity.h
+++ b/wit/src/Capacity.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CapacityH

--- a/wit/src/Coeff.h
+++ b/wit/src/Coeff.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CoeffH

--- a/wit/src/CompMgr.C
+++ b/wit/src/CompMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/CompMgr.h
+++ b/wit/src/CompMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CompMgrH

--- a/wit/src/Component.C
+++ b/wit/src/Component.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Component.h
+++ b/wit/src/Component.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ComponentH

--- a/wit/src/ConcRtCand.h
+++ b/wit/src/ConcRtCand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ConcRtCandH

--- a/wit/src/ConcRtSite.h
+++ b/wit/src/ConcRtSite.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ConcRtSiteH

--- a/wit/src/ConsEntry.h
+++ b/wit/src/ConsEntry.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ConsEntryH

--- a/wit/src/CplexMgr.C
+++ b/wit/src/CplexMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/CplexMgr.h
+++ b/wit/src/CplexMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CplexMgrH

--- a/wit/src/CplexMgrNC.h
+++ b/wit/src/CplexMgrNC.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CplexMgrNCH

--- a/wit/src/CpxParSpec.C
+++ b/wit/src/CpxParSpec.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/CpxParSpec.h
+++ b/wit/src/CpxParSpec.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CpxParSpecH

--- a/wit/src/CpxParSpecMgr.h
+++ b/wit/src/CpxParSpecMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CpxParSpecMgrH

--- a/wit/src/CstringLT.h
+++ b/wit/src/CstringLT.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef CstringLTH

--- a/wit/src/DataRead.C
+++ b/wit/src/DataRead.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/DataRead.h
+++ b/wit/src/DataRead.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DataReadH

--- a/wit/src/DataRepos.h
+++ b/wit/src/DataRepos.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DataReposH

--- a/wit/src/DataWrit.C
+++ b/wit/src/DataWrit.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/DataWrit.h
+++ b/wit/src/DataWrit.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DataWritH

--- a/wit/src/DelComp.h
+++ b/wit/src/DelComp.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DelCompH

--- a/wit/src/DelCompItr.h
+++ b/wit/src/DelCompItr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DelCompItrH

--- a/wit/src/Demand.C
+++ b/wit/src/Demand.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Demand.h
+++ b/wit/src/Demand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DemandH

--- a/wit/src/DetAltPt.h
+++ b/wit/src/DetAltPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DetAltPtH

--- a/wit/src/DetCons.C
+++ b/wit/src/DetCons.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/DetCons.h
+++ b/wit/src/DetCons.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DetConsH

--- a/wit/src/DetImpOP.C
+++ b/wit/src/DetImpOP.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/DetImpOP.h
+++ b/wit/src/DetImpOP.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DetImpOPH

--- a/wit/src/DetOptImpMgr.C
+++ b/wit/src/DetOptImpMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/DetOptImpMgr.h
+++ b/wit/src/DetOptImpMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DetOptImpMgrH

--- a/wit/src/DetSelPt.h
+++ b/wit/src/DetSelPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DetSelPtH

--- a/wit/src/DetVars.C
+++ b/wit/src/DetVars.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/DetVars.h
+++ b/wit/src/DetVars.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef DetVarsH

--- a/wit/src/Entity.C
+++ b/wit/src/Entity.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Entity.h
+++ b/wit/src/Entity.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef WitEntitH

--- a/wit/src/EqAll.C
+++ b/wit/src/EqAll.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/EqAll.h
+++ b/wit/src/EqAll.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef EqAllH

--- a/wit/src/ExecBS.h
+++ b/wit/src/ExecBS.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ExecBSH

--- a/wit/src/ExecPerSch.h
+++ b/wit/src/ExecPerSch.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ExecPerSchH

--- a/wit/src/ExpRest.h
+++ b/wit/src/ExpRest.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ExpRestH

--- a/wit/src/ExtOptMgr.C
+++ b/wit/src/ExtOptMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/ExtOptMgr.h
+++ b/wit/src/ExtOptMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ExtOptMgrH

--- a/wit/src/FSS.C
+++ b/wit/src/FSS.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/FSS.h
+++ b/wit/src/FSS.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef FSSH

--- a/wit/src/FeasChkr.C
+++ b/wit/src/FeasChkr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/FeasChkr.h
+++ b/wit/src/FeasChkr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef FeasChkrH

--- a/wit/src/FixedPer.h
+++ b/wit/src/FixedPer.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef FixedPerH

--- a/wit/src/FlexVAsst.h
+++ b/wit/src/FlexVAsst.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef FlexVAsstH

--- a/wit/src/FlexVec.C
+++ b/wit/src/FlexVec.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/FlexVec.h
+++ b/wit/src/FlexVec.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef FlexVecH

--- a/wit/src/FlowMon.h
+++ b/wit/src/FlowMon.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef FlowMonH

--- a/wit/src/FssMrp.h
+++ b/wit/src/FssMrp.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef FssMrpH

--- a/wit/src/GlobalComp.C
+++ b/wit/src/GlobalComp.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/GlobalComp.h
+++ b/wit/src/GlobalComp.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef GlobalCompH

--- a/wit/src/HeurAll.C
+++ b/wit/src/HeurAll.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/HeurAllMgr.h
+++ b/wit/src/HeurAllMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef HeurAllMgrH

--- a/wit/src/HeurAtor.C
+++ b/wit/src/HeurAtor.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/HeurAtor.h
+++ b/wit/src/HeurAtor.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef HeurAtorH

--- a/wit/src/HeurCrit.h
+++ b/wit/src/HeurCrit.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef HeurCritH

--- a/wit/src/HeurImp.C
+++ b/wit/src/HeurImp.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/HeurImp.h
+++ b/wit/src/HeurImp.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef HeurImpH

--- a/wit/src/HeurImpP.h
+++ b/wit/src/HeurImpP.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef HeurImpPH

--- a/wit/src/HeurModifier.C
+++ b/wit/src/HeurModifier.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/HeurModifier.h
+++ b/wit/src/HeurModifier.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef HeurModifierH

--- a/wit/src/ISRealArg.h
+++ b/wit/src/ISRealArg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ISRealArgH

--- a/wit/src/IVRealArg.h
+++ b/wit/src/IVRealArg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef IVRealArgH

--- a/wit/src/InputID.h
+++ b/wit/src/InputID.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef InputIDH

--- a/wit/src/IssueMsgExc.h
+++ b/wit/src/IssueMsgExc.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef IssueMsgExcH

--- a/wit/src/Link.h
+++ b/wit/src/Link.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef LinkH

--- a/wit/src/LinkMgr.h
+++ b/wit/src/LinkMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef LinkMgrH

--- a/wit/src/List.C
+++ b/wit/src/List.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/List.h
+++ b/wit/src/List.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ListH

--- a/wit/src/Mapping.C
+++ b/wit/src/Mapping.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Mapping.h
+++ b/wit/src/Mapping.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MappingH

--- a/wit/src/MatCap.C
+++ b/wit/src/MatCap.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Material.h
+++ b/wit/src/Material.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MaterialH

--- a/wit/src/MeCand.h
+++ b/wit/src/MeCand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MeCandH

--- a/wit/src/MeDir.h
+++ b/wit/src/MeDir.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MeDirH

--- a/wit/src/MeMgr.h
+++ b/wit/src/MeMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MeMgrH

--- a/wit/src/MePt.h
+++ b/wit/src/MePt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MePtH

--- a/wit/src/MeSitePt.h
+++ b/wit/src/MeSitePt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MeSitePtH

--- a/wit/src/Misc.C
+++ b/wit/src/Misc.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/MrCand.h
+++ b/wit/src/MrCand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MrCandH

--- a/wit/src/MrCoord.h
+++ b/wit/src/MrCoord.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MrCoordH

--- a/wit/src/MrMgr.h
+++ b/wit/src/MrMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MrMgrH

--- a/wit/src/MrPt.h
+++ b/wit/src/MrPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MrPtH

--- a/wit/src/MrSelMgr.h
+++ b/wit/src/MrSelMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MrSelMgrH

--- a/wit/src/MrSite.h
+++ b/wit/src/MrSite.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MrSiteH

--- a/wit/src/MrpExp.C
+++ b/wit/src/MrpExp.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/MrpExp.h
+++ b/wit/src/MrpExp.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MrpExpH

--- a/wit/src/Msg.h
+++ b/wit/src/Msg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MsgH

--- a/wit/src/MsgArg.h
+++ b/wit/src/MsgArg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MsgArgH

--- a/wit/src/MsgBuilder.C
+++ b/wit/src/MsgBuilder.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------
@@ -406,7 +398,7 @@ void WitMsgBuilder::buildMsgs ()
       97,
       info_,
       "%1$s\n"
-      "Watson Implosion Technology\n"
+      "Constrained Materials Management and Production Planning Tool\n"
       "Release         %2$s\n"
       "Build Date:     %3$s\n"
       "Build Type:     %4$s\n"

--- a/wit/src/MsgBuilder.h
+++ b/wit/src/MsgBuilder.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MsgBuilderH

--- a/wit/src/MsgFac.C
+++ b/wit/src/MsgFac.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/MsgFac.h
+++ b/wit/src/MsgFac.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MsgFacH

--- a/wit/src/MsgFrag.h
+++ b/wit/src/MsgFrag.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MsgFragH

--- a/wit/src/MsgMgr.C
+++ b/wit/src/MsgMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/MsgMgr.h
+++ b/wit/src/MsgMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MsgMgrH

--- a/wit/src/MultiEx.C
+++ b/wit/src/MultiEx.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/MultiObj.C
+++ b/wit/src/MultiObj.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/MultiObjMgr.h
+++ b/wit/src/MultiObjMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MultiObjMgrH

--- a/wit/src/MultiObjVecIR.h
+++ b/wit/src/MultiObjVecIR.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef MultiObjVecIRH

--- a/wit/src/MultiRoute.C
+++ b/wit/src/MultiRoute.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Node.h
+++ b/wit/src/Node.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef NodeH

--- a/wit/src/NodeSorter.C
+++ b/wit/src/NodeSorter.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/NodeSorter.h
+++ b/wit/src/NodeSorter.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef NodeSorterH

--- a/wit/src/NodeTable.h
+++ b/wit/src/NodeTable.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef NodeTableH

--- a/wit/src/OSRealArg.h
+++ b/wit/src/OSRealArg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OSRealArgH

--- a/wit/src/OTDARealArg.h
+++ b/wit/src/OTDARealArg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OTDARealArgH

--- a/wit/src/OVRealArg.h
+++ b/wit/src/OVRealArg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OVRealArgH

--- a/wit/src/ObjStack.h
+++ b/wit/src/ObjStack.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ObjStackH

--- a/wit/src/ObjStageMgr.h
+++ b/wit/src/ObjStageMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ObjStageMgrH

--- a/wit/src/ObjVec.C
+++ b/wit/src/ObjVec.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/ObjVec.h
+++ b/wit/src/ObjVec.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ObjVecH

--- a/wit/src/ObjVecIR.h
+++ b/wit/src/ObjVecIR.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ObjVecIRH

--- a/wit/src/Objective.h
+++ b/wit/src/Objective.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ObjectiveH

--- a/wit/src/OffsetProc.C
+++ b/wit/src/OffsetProc.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/OffsetProc.h
+++ b/wit/src/OffsetProc.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OffsetProcH

--- a/wit/src/Operation.C
+++ b/wit/src/Operation.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Operation.h
+++ b/wit/src/Operation.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OperationH

--- a/wit/src/OptComp.C
+++ b/wit/src/OptComp.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/OptComp.h
+++ b/wit/src/OptComp.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OptCompH

--- a/wit/src/OptCon.h
+++ b/wit/src/OptCon.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OptConH

--- a/wit/src/OptMisc.C
+++ b/wit/src/OptMisc.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/OptProblem.C
+++ b/wit/src/OptProblem.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //----------------------------------------------------------------------------

--- a/wit/src/OptProblem.h
+++ b/wit/src/OptProblem.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OptProblemH

--- a/wit/src/OptStarter.h
+++ b/wit/src/OptStarter.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OptStarterH

--- a/wit/src/OptVC.h
+++ b/wit/src/OptVC.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OptVCH

--- a/wit/src/OptVar.h
+++ b/wit/src/OptVar.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OptVarH

--- a/wit/src/OrigMrp.h
+++ b/wit/src/OrigMrp.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OrigMrpH

--- a/wit/src/OutDisp.h
+++ b/wit/src/OutDisp.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef OutDispH

--- a/wit/src/PairStack.h
+++ b/wit/src/PairStack.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PairStackH

--- a/wit/src/Param.C
+++ b/wit/src/Param.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Param.h
+++ b/wit/src/Param.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ParamH

--- a/wit/src/ParamMgr.C
+++ b/wit/src/ParamMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/ParamMgr.h
+++ b/wit/src/ParamMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ParamMgrH

--- a/wit/src/Parlex.C
+++ b/wit/src/Parlex.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Parlex.h
+++ b/wit/src/Parlex.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ParlexH

--- a/wit/src/Parser.h
+++ b/wit/src/Parser.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ParserH

--- a/wit/src/Part.C
+++ b/wit/src/Part.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Part.h
+++ b/wit/src/Part.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PartH

--- a/wit/src/PclBldr.h
+++ b/wit/src/PclBldr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PclBldrH

--- a/wit/src/PclEl.h
+++ b/wit/src/PclEl.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PclElH

--- a/wit/src/PegEl.h
+++ b/wit/src/PegEl.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PegElH

--- a/wit/src/Pegger.h
+++ b/wit/src/Pegger.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PeggerH

--- a/wit/src/Pegging.C
+++ b/wit/src/Pegging.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PenExMgr.h
+++ b/wit/src/PenExMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PenExMgrH

--- a/wit/src/PenExec.C
+++ b/wit/src/PenExec.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PerSglStack.h
+++ b/wit/src/PerSglStack.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PerSglStackH

--- a/wit/src/PerStageMgr.h
+++ b/wit/src/PerStageMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PerStageMgrH

--- a/wit/src/PipAttPgg.h
+++ b/wit/src/PipAttPgg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipAttPggH

--- a/wit/src/PipBuilder.C
+++ b/wit/src/PipBuilder.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PipBuilder.h
+++ b/wit/src/PipBuilder.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipBuilderH

--- a/wit/src/PipIncPgg.h
+++ b/wit/src/PipIncPgg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipIncPggH

--- a/wit/src/PipMgr.C
+++ b/wit/src/PipMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PipMgr.h
+++ b/wit/src/PipMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipMgrH

--- a/wit/src/PipPartReqMgr.C
+++ b/wit/src/PipPartReqMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PipPartReqMgr.h
+++ b/wit/src/PipPartReqMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipPartReqMgrH

--- a/wit/src/PipPgg.C
+++ b/wit/src/PipPgg.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PipPgg.h
+++ b/wit/src/PipPgg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipPggH

--- a/wit/src/PipRcpFac.h
+++ b/wit/src/PipRcpFac.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipRcpFacH

--- a/wit/src/PipRcpPgg.h
+++ b/wit/src/PipRcpPgg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipRcpPggH

--- a/wit/src/PipReq.C
+++ b/wit/src/PipReq.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PipReqBasis.h
+++ b/wit/src/PipReqBasis.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipReqBasisH

--- a/wit/src/PipReqCList.h
+++ b/wit/src/PipReqCList.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipReqCListH

--- a/wit/src/PipReqClient.h
+++ b/wit/src/PipReqClient.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipReqClientH

--- a/wit/src/PipReqMgr.C
+++ b/wit/src/PipReqMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PipReqMgr.h
+++ b/wit/src/PipReqMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipReqMgrH

--- a/wit/src/PipReqSpec.h
+++ b/wit/src/PipReqSpec.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipReqSpecH

--- a/wit/src/PipSeqMgr.h
+++ b/wit/src/PipSeqMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PipSeqMgrH

--- a/wit/src/Post.C
+++ b/wit/src/Post.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Post.h
+++ b/wit/src/Post.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PostH

--- a/wit/src/PrAltPt.h
+++ b/wit/src/PrAltPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PrAltPtH

--- a/wit/src/PrCand.h
+++ b/wit/src/PrCand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PrCandH

--- a/wit/src/PrCoord.h
+++ b/wit/src/PrCoord.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PrCoordH

--- a/wit/src/PrMgr.h
+++ b/wit/src/PrMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PrMgrH

--- a/wit/src/PrSelMgr.h
+++ b/wit/src/PrSelMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PrSelMgrH

--- a/wit/src/PrSelPt.h
+++ b/wit/src/PrSelPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PrSelPtH

--- a/wit/src/Pre.C
+++ b/wit/src/Pre.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Pre.h
+++ b/wit/src/Pre.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PreH

--- a/wit/src/PreHelp.C
+++ b/wit/src/PreHelp.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Problem.C
+++ b/wit/src/Problem.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Problem.h
+++ b/wit/src/Problem.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ProblemH

--- a/wit/src/PropRtg.C
+++ b/wit/src/PropRtg.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PtrMap.C
+++ b/wit/src/PtrMap.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PtrMap.h
+++ b/wit/src/PtrMap.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PtrMapH

--- a/wit/src/PtrSched.C
+++ b/wit/src/PtrSched.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/PtrSched.h
+++ b/wit/src/PtrSched.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PtrSchedH

--- a/wit/src/PtrTVec.h
+++ b/wit/src/PtrTVec.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PtrTVecH

--- a/wit/src/PtrVec.h
+++ b/wit/src/PtrVec.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef PtrVecH

--- a/wit/src/RealArg.C
+++ b/wit/src/RealArg.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/RealArg.h
+++ b/wit/src/RealArg.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef RealArgH

--- a/wit/src/Repos.C
+++ b/wit/src/Repos.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/ReqPt.h
+++ b/wit/src/ReqPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ReqPtH

--- a/wit/src/ReqPtMgr.h
+++ b/wit/src/ReqPtMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ReqPtMgrH

--- a/wit/src/ReqSched.h
+++ b/wit/src/ReqSched.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ReqSchedH

--- a/wit/src/Routing.C
+++ b/wit/src/Routing.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/RtAn.C
+++ b/wit/src/RtAn.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/RtAn.h
+++ b/wit/src/RtAn.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef RtAnH

--- a/wit/src/RtCand.h
+++ b/wit/src/RtCand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef RtCandH

--- a/wit/src/RtMgr.h
+++ b/wit/src/RtMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef RtMgrH

--- a/wit/src/RtSite.h
+++ b/wit/src/RtSite.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef RtSiteH

--- a/wit/src/SaeMgr.C
+++ b/wit/src/SaeMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/SaeMgr.h
+++ b/wit/src/SaeMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SaeMgrH

--- a/wit/src/ScenAtt.C
+++ b/wit/src/ScenAtt.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/ScenAtt.h
+++ b/wit/src/ScenAtt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ScenAttH

--- a/wit/src/ScenAttMgr.C
+++ b/wit/src/ScenAttMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/ScenAttMgr.h
+++ b/wit/src/ScenAttMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ScenAttMgrH

--- a/wit/src/ScenGroup.h
+++ b/wit/src/ScenGroup.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ScenGroupH

--- a/wit/src/ScenInputAtt.h
+++ b/wit/src/ScenInputAtt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ScenInputAttH

--- a/wit/src/ScenMgr.h
+++ b/wit/src/ScenMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ScenMgrH

--- a/wit/src/ScenSolnAtt.h
+++ b/wit/src/ScenSolnAtt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ScenSolnAttH

--- a/wit/src/Scenario.C
+++ b/wit/src/Scenario.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Scenario.h
+++ b/wit/src/Scenario.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ScenarioH

--- a/wit/src/Schedule.C
+++ b/wit/src/Schedule.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Schedule.h
+++ b/wit/src/Schedule.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef ScheduleH

--- a/wit/src/SelCand.h
+++ b/wit/src/SelCand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SelCandH

--- a/wit/src/SelMgr.h
+++ b/wit/src/SelMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SelMgrH

--- a/wit/src/SelPt.h
+++ b/wit/src/SelPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SelPtH

--- a/wit/src/SelSplit.C
+++ b/wit/src/SelSplit.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/SelStRe.C
+++ b/wit/src/SelStRe.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Selection.C
+++ b/wit/src/Selection.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Selector.C
+++ b/wit/src/Selector.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Selector.h
+++ b/wit/src/Selector.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SelectorH

--- a/wit/src/Session.C
+++ b/wit/src/Session.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------
@@ -100,17 +92,17 @@
 
 const char * const WitSession::proprietaryStmt_ =
    "\n"
-   "=======================================================\n"
+   "=============================================================\n"
    "Licensed Materials - Property of IBM\n"
    "\n"
-   "Watson Implosion Technology\n"
+   "Constrained Materials Management and Production Planning Tool\n"
    "\n"
    "(C) Copyright IBM Corp. 1993, 2012  All Rights Reserved\n"
    "\n"
    "US Government Users Restricted Rights -\n"
    "Use, duplication or disclosure restricted by\n"
    "GSA ADP Schedule Contract with IBM Corp.\n"
-   "=======================================================\n";
+   "=============================================================\n";
 
 //------------------------------------------------------------------------------
 
@@ -146,7 +138,7 @@ void WitSession::writeHeading (FILE * outFile)
    {
    fprintf (outFile,
       "%s\n"
-      "Watson Implosion Technology\n"
+      "Constrained Materials Management and Production Planning Tool\n"
       "Release         %s\n"
       "Build Date:     %s\n"
       "Build Type:     %s\n"

--- a/wit/src/Session.h
+++ b/wit/src/Session.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SessionH

--- a/wit/src/SglObjVecIR.h
+++ b/wit/src/SglObjVecIR.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SglObjVecIRH

--- a/wit/src/SglSrcMgr.C
+++ b/wit/src/SglSrcMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/SglSrcMgr.h
+++ b/wit/src/SglSrcMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SglSrcMgrH

--- a/wit/src/SglSrcSite.C
+++ b/wit/src/SglSrcSite.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/SglSrcSite.h
+++ b/wit/src/SglSrcSite.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SglSrcSiteH

--- a/wit/src/SolnWrit.C
+++ b/wit/src/SolnWrit.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/SolnWrit.h
+++ b/wit/src/SolnWrit.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SolnWritH

--- a/wit/src/SplitCntr.h
+++ b/wit/src/SplitCntr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SplitCntrH

--- a/wit/src/SplitPt.h
+++ b/wit/src/SplitPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SplitPtH

--- a/wit/src/Splitter.h
+++ b/wit/src/Splitter.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SplitterH

--- a/wit/src/SsrCand.h
+++ b/wit/src/SsrCand.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SsrCandH

--- a/wit/src/SsrMgr.h
+++ b/wit/src/SsrMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SsrMgrH

--- a/wit/src/SsrPt.h
+++ b/wit/src/SsrPt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SsrPtH

--- a/wit/src/StCons.C
+++ b/wit/src/StCons.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/StCons.h
+++ b/wit/src/StCons.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StConsH

--- a/wit/src/StVars.C
+++ b/wit/src/StVars.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/StVars.h
+++ b/wit/src/StVars.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StVarsH

--- a/wit/src/Stack.C
+++ b/wit/src/Stack.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Stack.h
+++ b/wit/src/Stack.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StackH

--- a/wit/src/Stage.C
+++ b/wit/src/Stage.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Stage.h
+++ b/wit/src/Stage.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StageH

--- a/wit/src/StageMgr.h
+++ b/wit/src/StageMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StageMgrH

--- a/wit/src/StochAssoc.h
+++ b/wit/src/StochAssoc.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochAssocH

--- a/wit/src/StochAtt.h
+++ b/wit/src/StochAtt.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochAttH

--- a/wit/src/StochAttMgr.h
+++ b/wit/src/StochAttMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochAttMgrH

--- a/wit/src/StochCon.h
+++ b/wit/src/StochCon.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochConH

--- a/wit/src/StochImpMgr.C
+++ b/wit/src/StochImpMgr.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/StochImpMgr.h
+++ b/wit/src/StochImpMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochImpMgrH

--- a/wit/src/StochImpOP.h
+++ b/wit/src/StochImpOP.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochImpOPH

--- a/wit/src/StochLoc.h
+++ b/wit/src/StochLoc.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochLocH

--- a/wit/src/StochMode.C
+++ b/wit/src/StochMode.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/StochModeMgr.h
+++ b/wit/src/StochModeMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochModeMgrH

--- a/wit/src/StochOpt.C
+++ b/wit/src/StochOpt.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/StochOptMgr.h
+++ b/wit/src/StochOptMgr.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochOptMgrH

--- a/wit/src/StochVar.h
+++ b/wit/src/StochVar.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StochVarH

--- a/wit/src/StockBS.h
+++ b/wit/src/StockBS.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StockBSH

--- a/wit/src/Str.h
+++ b/wit/src/Str.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef StrH

--- a/wit/src/SubEntry.C
+++ b/wit/src/SubEntry.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/SubEntry.h
+++ b/wit/src/SubEntry.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SubEntryH

--- a/wit/src/SymTable.C
+++ b/wit/src/SymTable.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/SymTable.h
+++ b/wit/src/SymTable.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef SymTableH

--- a/wit/src/TVec.h
+++ b/wit/src/TVec.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef TVecH

--- a/wit/src/TempMsgFile.h
+++ b/wit/src/TempMsgFile.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef TempMsgFileH

--- a/wit/src/Timing.C
+++ b/wit/src/Timing.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Timing.h
+++ b/wit/src/Timing.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef TimingH

--- a/wit/src/TripStack.h
+++ b/wit/src/TripStack.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef TripStackH

--- a/wit/src/Util.C
+++ b/wit/src/Util.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Util.h
+++ b/wit/src/Util.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef UtilH

--- a/wit/src/VarRepos.h
+++ b/wit/src/VarRepos.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef VarReposH

--- a/wit/src/Variant.h
+++ b/wit/src/Variant.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef VariantH

--- a/wit/src/VecBS.C
+++ b/wit/src/VecBS.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/VecBS.h
+++ b/wit/src/VecBS.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef VecBSH

--- a/wit/src/VecWriter.h
+++ b/wit/src/VecWriter.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef VecWriterH

--- a/wit/src/Vecs.C
+++ b/wit/src/Vecs.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/Vector.h
+++ b/wit/src/Vector.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef VectorH

--- a/wit/src/WitRun.C
+++ b/wit/src/WitRun.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/WitRun.h
+++ b/wit/src/WitRun.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef WitRunH

--- a/wit/src/api.C
+++ b/wit/src/api.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/bomApi.C
+++ b/wit/src/bomApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/bopApi.C
+++ b/wit/src/bopApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/demApi.C
+++ b/wit/src/demApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/globApi.C
+++ b/wit/src/globApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/macs.h
+++ b/wit/src/macs.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef macs_h

--- a/wit/src/msgApi.C
+++ b/wit/src/msgApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/opnApi.C
+++ b/wit/src/opnApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/optApi.C
+++ b/wit/src/optApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/partApi.C
+++ b/wit/src/partApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/stochApi.C
+++ b/wit/src/stochApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/subApi.C
+++ b/wit/src/subApi.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/typedefs.h
+++ b/wit/src/typedefs.h
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 #ifndef typedefs_h

--- a/wit/src/wit.C
+++ b/wit/src/wit.C
@@ -1,15 +1,7 @@
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 //------------------------------------------------------------------------------

--- a/wit/src/wit.h
+++ b/wit/src/wit.h
@@ -1,15 +1,7 @@
 /*============================================================================*/
-/* IBM Confidential                                                           */
-/*                                                                            */
-/* OCO Source Materials                                                       */
-/*                                                                            */
-/* Watson Implosion Technology                                                */
+/* Constrained Materials Management and Production Planning Tool              */
 /*                                                                            */
 /* (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved                    */
-/*                                                                            */
-/* The Source code for this program is not published or otherwise divested of */
-/* its trade secrets, irrespective of what has been deposited with the U. S.  */
-/* Copyright office.                                                          */
 /*============================================================================*/
 
 #ifndef wit_h

--- a/wit/src/witLexer.C
+++ b/wit/src/witLexer.C
@@ -505,17 +505,9 @@ char *yytext_ptr;
 #define INITIAL 0
 #line 2 "../src/witLexer.l"
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 /*------------------------------------------------------------------------------

--- a/wit/src/witLexer.l
+++ b/wit/src/witLexer.l
@@ -1,16 +1,8 @@
 %{
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 /*------------------------------------------------------------------------------

--- a/wit/src/witParse.C
+++ b/wit/src/witParse.C
@@ -137,17 +137,9 @@
 #line 1 "../src/witParse.y"
 
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 /*------------------------------------------------------------------------------

--- a/wit/src/witParse.y
+++ b/wit/src/witParse.y
@@ -1,16 +1,8 @@
 %{
 //==============================================================================
-// IBM Confidential
-//
-// OCO Source Materials
-//
-// Watson Implosion Technology
+// Constrained Materials Management and Production Planning Tool
 //
 // (C) Copyright IBM Corp. 1993, 2012  All Rights Reserved
-//
-// The Source code for this program is not published or otherwise divested of
-// its trade secrets, irrespective of what has been deposited with the U. S.
-// Copyright office.
 //==============================================================================
 
 /*------------------------------------------------------------------------------


### PR DESCRIPTION
Removed "IBM Confidential".
Removed "OCO Source Materials".
Replaced "Watson Implosion Technology" with "Constrained Materials Management and Production Planning Tool".
Removed "The Source code for this program is not published ...".

All IBM copyright notices were left in place.